### PR TITLE
Update stack.yaml

### DIFF
--- a/ghc-vis.cabal
+++ b/ghc-vis.cabal
@@ -50,7 +50,7 @@ Library
                  gtk3 >= 0.12 && < 0.15,
                  svgcairo >= 0.12 && < 0.14,
                  cairo >= 0.12 && < 0.14,
-                 ghc-heap-view >= 0.5
+                 ghc-heap-view >= 0.5 && < 0.6
   Hs-source-dirs: src/
   Ghc-options: -Wall -fno-warn-unused-do-bind
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,9 @@
 resolver: lts-8.8
 packages:
 - '.'
-- location:
-    git: https://github.com/nomeata/ghc-heap-view.git
-    commit: 368068c5c208323d690ece6a9bfb8aa843a95537
-  extra-dep: true 
 extra-deps:
 - xdot-0.3.0.1
 - svgcairo-0.13.1.1
+- git: https://github.com/nomeata/ghc-heap-view.git
+  commit: 368068c5c208323d690ece6a9bfb8aa843a95537
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
 - '.'
 extra-deps:
 - xdot-0.3.0.1
-- svgcairo-0.13.1.1
+- svgcairo-0.13.2.0
 - git: https://github.com/nomeata/ghc-heap-view.git
   commit: 368068c5c208323d690ece6a9bfb8aa843a95537
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,3 @@ packages:
 extra-deps:
 - xdot-0.3.0.1
 - svgcairo-0.13.2.0
-- git: https://github.com/nomeata/ghc-heap-view.git
-  commit: 368068c5c208323d690ece6a9bfb8aa843a95537
-


### PR DESCRIPTION
- The `extra-dep` key is no longer supported in newer versions of `stack`
- Reference `svgcairo-0.13.2.0` in `stack.yaml`
- `ghc-heap-view-0.5.9` is resolvable using `lts-8.8` and therefore doesn't need to be references as an `extra-dep` in `stack.yaml`